### PR TITLE
fix(build): generate docs fail due to missing gh token

### DIFF
--- a/.github/workflows/generate-docs.yaml
+++ b/.github/workflows/generate-docs.yaml
@@ -24,8 +24,6 @@ jobs:
 
       - name: Submit Pull Request
         id: push_image_info
-        env:
-          GITHUB_TOKEN: ${{ secrets.PAT }}
         run: |
           set -e
           echo "Start."
@@ -56,3 +54,5 @@ jobs:
               -f head="$branch" \
               -f base='main'
           fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
this changeset is to fix the build workflow failure due to missing gh token variable.